### PR TITLE
FT-024669 - Improve the security of the iOS mobile app (appInstanceID on rooted devices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Cordova Advanced HTTP
 
 Cordova / Phonegap plugin for communicating with HTTP servers.  Supports iOS, Android and [Browser](#browserSupport).
 
+## Esker-Software Fork diff :
+- Add ability to store cookie in another storage : setCookieStorageImpl
+- iOS only : Disable cache from NSURLSessionConfiguration  
+
+## Readme from original fork
 This is a fork of [Wymsee's Cordova-HTTP plugin](https://github.com/wymsee/cordova-HTTP).
 
 ## Advantages over Javascript requests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cordova / Phonegap plugin for communicating with HTTP servers.  Supports iOS, An
 
 ## Esker-Software Fork diff :
 - Add ability to store cookie in another storage : setCookieStorageImpl
-- iOS only : Disable cache from NSURLSessionConfiguration  
+- iOS only : Disable cache from [NSURLSessionConfiguration](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1410148-urlcache)
 
 ## Readme from original fork
 This is a fork of [Wymsee's Cordova-HTTP plugin](https://github.com/wymsee/cordova-HTTP).

--- a/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
@@ -513,12 +513,6 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     }
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
-    //  ESKER MODIFICATION                                                                                          //
-    //  FT-024669 - Improve the security of the iOS mobile app (appInstanceID on rooted devices)                    //
-    //  Disable caches as recommended by security pentest                                                           //
-    //  https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1410148-urlcache             //
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     configuration.URLCache = nil;
 
     self.sessionConfiguration = configuration;

--- a/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
@@ -513,8 +513,13 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     }
 
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////// 
+    //  ESKER MODIFICATION                                                                                          //
+    //  FT-024669 - Improve the security of the iOS mobile app (appInstanceID on rooted devices)                    //
+    //  Disable caches as recommended by security pentest                                                           //
+    //  https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1410148-urlcache             //
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     configuration.URLCache = nil;
-    configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 
     self.sessionConfiguration = configuration;
 

--- a/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
+++ b/src/ios/SM_AFNetworking/SM_AFURLSessionManager.m
@@ -513,6 +513,9 @@ static NSString * const AFNSURLSessionTaskDidSuspendNotification = @"com.alamofi
         configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     }
 
+    configuration.URLCache = nil;
+    configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+
     self.sessionConfiguration = configuration;
 
     self.operationQueue = [[NSOperationQueue alloc] init];


### PR DESCRIPTION
Disable HTTP cache on  request to prevent information leak on jailbreak device.